### PR TITLE
Fixes issue of Profane warning for `Just`

### DIFF
--- a/config.json
+++ b/config.json
@@ -8,6 +8,7 @@
             "dad-mom",
             "brother-sister",
             "just"
+            "easy"
         ]
     }
 }

--- a/config.json
+++ b/config.json
@@ -6,7 +6,8 @@
             "her-him",
             "gal-guy",
             "dad-mom",
-            "brother-sister"
+            "brother-sister",
+            "just"
         ]
     }
 }


### PR DESCRIPTION
<!--Type in all the issues that have been fixed through this pull request ex : #1 -->

## Fixes Issue

This PR fixes the following issues:

Monitor was throwing a profane language warning when the word `Just` was invoked. 
 - Added the word `Just` to allowed words for alexjs
<!-- Write down all the changes made-->




## Check List (Check all the boxes which are applicable) <!--Follow the above conventions to check the box-->

- [x ] My code follows the code style of this project.
- [ x] My change requires a change to the documentation.
- [ x] I have updated the documentation accordingly.
- [ x] All new and existing tests passed.
- [ x] This PR does not contain plagiarized content.
- [ x] The title of my pull request is a short description of the requested changes.


<!--Add screen shots of the changed output-->
## Screenshots 
Add all the screenshots which support your changes
